### PR TITLE
add a link to the documentation for the DOM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,17 @@ SAFE App API plugin for SAFE Browser.
 |:---:|:--------:|
 |[![Build Status](https://travis-ci.org/maidsafe/beaker-plugin-safe-app.svg?branch=master)](https://travis-ci.org/maidsafe/beaker-plugin-safe-app)|[![Build status](https://ci.appveyor.com/api/projects/status/684fxjpg88vu87hf/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/beaker-plugin-safe-app/branch/master)|
 
+## Documentation
+
+The documentation for the safeApp DOM API is available at http://docs.maidsafe.net/beaker-plugin-safe-app/.
+
 ## Dependency
 
 Project depends on [safe_app_nodejs](https://github.com/maidsafe/safe_app_nodejs). The dependency is specified as a git submodule.
 
 ## Development
 
-Rust and Nodejs are required for development.
+Rust and Node.js are required for development.
 
 1. Clone the project
 2. Run `npm i` to install the nodejs dependency


### PR DESCRIPTION
We could add a link to http://docs.maidsafe.net/beaker-plugin-safe-app/ in the README to make it easier for people to find the documentation 🙂