### PR TITLE
Add safe-logs protocol [MAID-2232]

### DIFF
--- a/src/log-list-template.ejs
+++ b/src/log-list-template.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>SAFE App Logs</title>
+		<style><%= css %></style>
+
+	</head>
+	<body>
+		<h1>SAFE Network</h1>
+		<h4 class="desc"><span>Privacy</span><span>Security</span><span>Freedom</span></h4>
+		<h2>SAFE App Logs</h2>
+    <ul>
+      <% logList.forEach(function(log){ %>
+        <li><a href="safe-logs:<%= log.name %>" ><%= log.name %></a></li>
+      <% }); %>
+    </ul>
+	</body>
+</html>

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -1,3 +1,5 @@
+import { setupSafeLogProtocol } from './safe-logs';
+
 const path = require('path');
 const safeApp = require('safe-app');
 const urlParse = require('url').parse;
@@ -7,10 +9,11 @@ const ipc = require('./api/ipc');
 const protocol = require('electron').protocol;
 
 const errorTemplate = require('./error-template.ejs');
-const errorCss = require('./error-page.css');
+const safeCss = require('./safe-pages.css');
 
 const safeScheme = 'safe';
 const safeLocalScheme = 'localhost';
+const safeLogScheme = 'safe-logs';
 
 const appInfo = {
   id: 'net.maidsafe.app.browser',
@@ -49,7 +52,7 @@ const fetchData = (url) => {
 
 
 const handleError = (err, mimeType, cb) => {
-  err.css = errorCss;
+  err.css = safeCss;
 
   const page = errorTemplate(err);
 
@@ -89,6 +92,10 @@ const registerSafeProtocol = () => {
   });
 };
 
+export const registerSafeLogs = () => {
+  setupSafeLogProtocol(appInfo);
+};
+
 module.exports = [{
   scheme: safeScheme,
   label: 'SAFE',
@@ -101,4 +108,9 @@ module.exports = [{
   isStandardURL: true,
   isInternal: true,
   register: registerSafeLocalProtocol
+},
+{
+  scheme: safeLogScheme,
+  label: 'SAFE-logs',
+  register: registerSafeLogs
 }];

--- a/src/safe-logs.js
+++ b/src/safe-logs.js
@@ -1,0 +1,120 @@
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+import fs from 'fs-extra';
+import url from 'url';
+import path from 'path';
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+import { protocol } from 'electron';
+import safeApp from 'safe-app';
+import safeCss from './safe-pages.css';
+
+const logListTemplate = require('./log-list-template.ejs');
+
+let appObj = null;
+
+
+/**
+ * Get the browser logfile from appObj
+ * @param  { String } appToken app token
+ * @return { Promise }        resolves to the app log path
+ */
+export const getLogs = (appInfo, attempt = 0) => {
+
+  return new Promise((resolve, reject) => {
+    if (appObj) {
+      appObj.logPath()
+      .then(resolve)
+      .catch(reject);
+    } else {
+      safeApp.initializeApp(appInfo)
+      .then((app) => {
+        appObj = app;
+        return getLogs();
+      })
+      .catch(reject);
+    }
+  });
+};
+
+
+/**
+ * Get the list of all logs stored on the file system, uses safeApp to get log folder from
+ * the default log file.
+ * @param  {String}   appInfo safe app info
+ * @return {Array}    all log files
+ */
+function getLogsList(appInfo) {
+
+  return getLogs(appInfo)
+  .then((defaultLog) => {
+    const logsDir = path.dirname(defaultLog);
+    const logFiles = [];
+
+    return new Promise((resolve, reject) => {
+      const files = fs.readdirSync(logsDir, 'utf-8');
+      files.map((file) => path.join(logsDir, file) )
+        .filter((file) => {
+          const ext = path.extname(file);
+          return ext === '.log';
+        })
+        .forEach((file) => {
+          const name = path.basename(file);
+          const logFile = {
+            file,
+            name
+          };
+          logFiles.push(logFile);
+        });
+
+      resolve(logFiles);
+    });
+  })
+}
+
+/**
+ * Renders the log list using the log template
+ * @param  { Object }   appInfo safe app ingo
+ * @param  {Function} cb      protocol request callback
+ * @return {[type]}           the callback
+ */
+function showLogList(appInfo, cb) {
+  getLogsList(appInfo)
+  .then((logList) => {
+
+    const page = logListTemplate({ logList, css: safeCss });
+
+    return cb({ mimeType: 'text/html', data: Buffer.from(page) });
+  })
+  .catch(console.error);
+}
+
+
+/**
+ * Setup the protocol for logs, and if needed, retrieve all logs / return
+ * the log page.
+ * @param  {Object} appInfo safe app ingo
+ */
+export function setupSafeLogProtocol(appInfo) {
+  getLogs(appInfo);
+
+  protocol.registerBufferProtocol('safe-logs', (request, cb) => {
+    const parsedUrl = url.parse(request.url);
+    const fileName = parsedUrl.hostname;
+
+    if (fileName === 'list') {
+      showLogList(appInfo, cb);
+    } else {
+      getLogs(appInfo)
+      .then((defaultLog) => {
+        const logsDir = path.dirname(defaultLog);
+        const logFile = path.resolve(logsDir, fileName);
+
+        fs.readFile(logFile, (err, logBuffer) => {
+          if (err) {
+            throw err;
+          }
+          cb(logBuffer);
+        });
+      });
+    }
+  });
+}

--- a/src/safe-pages.css
+++ b/src/safe-pages.css
@@ -24,7 +24,6 @@ h1
 	margin-bottom:   0;
 }
 
-
 h4
 {
 	font-size:       18px;
@@ -61,4 +60,42 @@ h4
 .desc span:last-child::after
 {
   display:         none;
+}
+
+
+
+a
+{
+  cursor: pointer;
+  color: #016fde;
+  text-decoration: none;
+}
+
+a:hover
+{
+  text-decoration: underline;
+  color: #0091ff;
+}
+
+a:active,
+a:hover
+{
+    outline: 0;
+}
+
+
+
+
+
+ul
+{
+  padding-left: 0;
+}
+
+li
+{
+  list-style-type: none;
+  margin: 20px 0 0;
+  padding: 0;
+  font-size: 14px;
 }


### PR DESCRIPTION
Adds protocol handling and related functionality to create a safeApp log list page and enable logs to be easily viewed in the browser.

Depends upon: https://github.com/maidsafe/beaker-plugin-safe-app/pull/56

as there are shared templating / styles functionality. (I can pull this out as a separate commit/PR if needs be).

Requires:

https://github.com/maidsafe/safe_app_nodejs/pull/127


