### PR TITLE
MAID-2300 fix/Flag when the authorisation request is for an unregistered client

### DIFF
--- a/src/api/app.js
+++ b/src/api/app.js
@@ -79,7 +79,7 @@ module.exports.connect = (appHandle) => {
   return new Promise((resolve, reject) => {
     getObj(appHandle)
       .then((obj) => obj.app.auth.genConnUri()
-        .then((connReq) => ipc.sendAuthReq(connReq, (err, res) => {
+        .then((connReq) => ipc.sendAuthReq(connReq, true, (err, res) => {
           if (err) {
             return reject(new Error('Unable to get connection information: ', err));
           }
@@ -121,7 +121,7 @@ module.exports.authorise = (appHandle, permissions, options) => {
   return new Promise((resolve, reject) => {
     getObj(appHandle)
       .then((obj) => obj.app.auth.genAuthUri(permissions, options)
-        .then((authReq) => ipc.sendAuthReq(authReq, (err, res) => {
+        .then((authReq) => ipc.sendAuthReq(authReq, false, (err, res) => {
           if (err) {
             return reject(new Error('Unable to authorise the application: ', err));
           }
@@ -186,7 +186,7 @@ module.exports.authoriseContainer = (appHandle, permissions) => {
   return new Promise((resolve, reject) => {
     getObj(appHandle)
       .then((obj) => obj.app.auth.genContainerAuthUri(permissions)
-        .then((authReq) => ipc.sendAuthReq(authReq, (err, res) => {
+        .then((authReq) => ipc.sendAuthReq(authReq, false, (err, res) => {
           if (err) {
             return reject(new Error('Unable to authorise the application: ', err)); // TODO send Error in specific
           }
@@ -225,7 +225,7 @@ module.exports.authoriseShareMd = (appHandle, permissions) => {
   return new Promise((resolve, reject) => {
     getObj(appHandle)
       .then((obj) => obj.app.auth.genShareMDataUri(permissions)
-        .then((authReq) => ipc.sendAuthReq(authReq, (err, res) => {
+        .then((authReq) => ipc.sendAuthReq(authReq, false, (err, res) => {
           if (err) {
             return reject(new Error('Unable to authorise the application: ', err)); // TODO send Error in specific
           }

--- a/src/api/ipc.js
+++ b/src/api/ipc.js
@@ -42,7 +42,7 @@ class IpcTask {
     }
     this.isProcessing = true;
     this.currentTaskId = this.tasks[0];
-    const currentTask = currentTask;
+    const currentTask = this.tasksInfo[this.currentTaskId];
     this.currentTaskInfo = currentTask.info;
     this.currentTaskCb = currentTask.cb;
     ipcEvent.sender.send('webClientAuthReq', this.currentTaskInfo, currentTask.unregistered);

--- a/src/protocol.js
+++ b/src/protocol.js
@@ -28,9 +28,9 @@ const authoriseApp = () => {
     if (appObj) {
       return resolve(true);
     }
-    return safeApp.initializeApp(appInfo, (state) => {console.log('NETWORK STATE CHANGED TO: ', state);})
+    return safeApp.initializeApp(appInfo, (state) => {console.log('Network state changed to: ', state);})
       .then((app) => app.auth.genConnUri()
-        .then((connReq) => ipc.sendAuthReq(connReq, (err, res) => {
+        .then((connReq) => ipc.sendAuthReq(connReq, true, (err, res) => {
           if (err) {
             return reject(new Error('Unable to get connection information: ', err));
           }


### PR DESCRIPTION
Flag when the authorisation request is for an unregistered client so it can be handled in parallel to the requests for registered clients which may be hold in queue awaiting for the user to either log in or to authorise them.